### PR TITLE
Update build.yaml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,6 +47,7 @@ jobs:
           file: ./Dockerfile
           platforms: linux/${{ matrix.arch }}
           push: ${{ github.event_name != 'pull_request' }}
+          provenance: false
           tags: |
             ghcr.io/pddg/latex:latest-${{ matrix.arch }}
             ghcr.io/pddg/latex:${{ env.VERSION }}-${{ matrix.arch }}


### PR DESCRIPTION
The "ghcr.io/***/latex:3.1.0-amd64 is a manifest list" error is probably due to an update of the "docker manifest" command.
Adding the option "provenance: false" seems to solve the problem.